### PR TITLE
fix migrations for python 3

### DIFF
--- a/djangocms_file/migrations/0004_auto_20160119_1534.py
+++ b/djangocms_file/migrations/0004_auto_20160119_1534.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import cms.models.pluginmodel
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('djangocms_file', '0003_rename_file_field_20160115_1904'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='file',
+            name='source',
+            field=models.FileField(upload_to=cms.models.pluginmodel.get_plugin_media_path, verbose_name='source'),
+        ),
+        migrations.AlterField(
+            model_name='file',
+            name='target',
+            field=models.CharField(blank=True, max_length=100, choices=[('', 'same window'), ('_blank', 'new window'), ('_parent', 'parent window'), ('_top', 'topmost frame')], help_text='Optional link target.', default='', verbose_name='target'),
+        ),
+    ]


### PR DESCRIPTION
django migration file `0002_auto_20151202_1551.py` introduced bytestring literals on the choices kwarg for `djangocms_file.models.File.target` field

as the model itself was not changed, running with `djangocms_file` in a python 3.x environment complains that migrations are missing.  

This can be fixed by removing the `b''` literals in `0002_auto_20151202_1551.py` or with a new migration