### PR TITLE
adapted testing infrastructure, migrations and naming

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,15 +7,15 @@ env:
   - TOX_ENV=py27-latest
   - TOX_ENV=py34-latest
   # Django 1.8
-  - TOX_ENV=py34-dj18-cms33
-  - TOX_ENV=py34-dj18-cms32
+  - TOX_ENV=py27-dj18-cms34
   - TOX_ENV=py27-dj18-cms33
-  - TOX_ENV=py27-dj18-cms32
+  - TOX_ENV=py34-dj18-cms34
+  - TOX_ENV=py34-dj18-cms33
   # Django 1.9
-  - TOX_ENV=py34-dj19-cms33
-  - TOX_ENV=py34-dj19-cms32
+  - TOX_ENV=py27-dj19-cms34
   - TOX_ENV=py27-dj19-cms33
-  - TOX_ENV=py27-dj19-cms32
+  - TOX_ENV=py34-dj19-cms34
+  - TOX_ENV=py34-dj19-cms33
 
 install:
   - pip install tox coverage

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,16 @@ Changelog
 =========
 
 
+2.0.2 (unreleased)
+==================
+
+* Prevent changes to ``DJANGOCMS_FILE_XXX`` settings from requiring new
+  migrations
+* Changed naming of ``Aldryn`` to ``Divio Cloud``
+* Adapted testing infrastructure (tox/travis) to incorporate
+  django CMS 3.4 and dropped 3.2
+
+
 2.0.1 (2016-20-09)
 ==================
 

--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ an entire folder.
 
 It uses files managed by `Django Filer <https://github.com/divio/django-filer>`_.
 
-This addon is compatible with `Aldryn <http://aldryn.com>`_ and is also available on the
+This addon is compatible with `Divio Cloud <http://divio.com>`_ and is also available on the
 `django CMS Marketplace <https://marketplace.django-cms.org/en/addons/browse/djangocms-file/>`_
 for easy installation.
 

--- a/djangocms_file/migrations/0007_adapted_fields.py
+++ b/djangocms_file/migrations/0007_adapted_fields.py
@@ -5,6 +5,7 @@ from django.db import migrations, models
 import django.db.models.deletion
 import filer.fields.file
 import djangocms_attributes_field.fields
+from djangocms_file.models import get_templates
 
 
 class Migration(migrations.Migration):
@@ -22,7 +23,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='file',
             name='template',
-            field=models.CharField(default='default', max_length=255, verbose_name='Template', choices=[('default', 'Default')]),
+            field=models.CharField(default=get_templates()[0][0], max_length=255, verbose_name='Template', choices=get_templates()),
         ),
         migrations.RenameField(
             model_name='file',

--- a/djangocms_file/migrations/0008_add_folder.py
+++ b/djangocms_file/migrations/0008_add_folder.py
@@ -5,6 +5,7 @@ from django.db import migrations, models
 import django.db.models.deletion
 import filer.fields.folder
 import djangocms_attributes_field.fields
+from djangocms_file.models import get_templates
 
 
 class Migration(migrations.Migration):
@@ -19,7 +20,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Folder',
             fields=[
-                ('template', models.CharField(default='default', max_length=255, verbose_name='Template', choices=[('default', 'Default')])),
+                ('template', models.CharField(default=get_templates()[0][0], max_length=255, verbose_name='Template', choices=get_templates())),
                 ('link_target', models.CharField(default='', max_length=255, verbose_name='Link target', blank=True, choices=[('_self', 'Open in same window'), ('_blank', 'Open in new window'), ('_parent', 'Delegate to parent'), ('_top', 'Delegate to top')])),
                 ('show_file_size', models.BooleanField(default=False, help_text='Appends the file size at the end of the name.', verbose_name='Show file size')),
                 ('attributes', djangocms_attributes_field.fields.AttributesField(default=dict, verbose_name='Attributes', blank=True)),

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 envlist =
     flake8
     py{34,27}-latest
-    py{34,27}-dj18-cms{33,32}
-    py{34,27}-dj19-cms{33,32}
+    py{34,27}-dj18-cms{34,33}
+    py{34,27}-dj19-cms{34,33}
 
 skip_missing_interpreters=True
 
@@ -14,8 +14,8 @@ deps =
     dj18: Django>=1.8,<1.9
     dj19: Django>=1.9,<1.10
     latest: django-cms
-    cms32: django-cms>=3.2,<3.3
     cms33: django-cms>=3.3,<3.4
+    cms34: django-cms>=3.4,<3.5
 commands =
     {envpython} --version
     {env:COMMAND:coverage} erase


### PR DESCRIPTION
* Prevent changes to ``DJANGOCMS_FILE_XXX`` settings from requiring new
  migrations
* Changed naming of ``Aldryn`` to ``Divio Cloud``
* Adapted testing infrastructure (tox/travis) to incorporate
  django CMS 3.4 and dropped 3.2
