### PR TITLE
Improve readability of Folder.get_files

### DIFF
--- a/djangocms_file/models.py
+++ b/djangocms_file/models.py
@@ -178,8 +178,6 @@ class Folder(CMSPlugin):
         self.folder_src = oldinstance.folder_src
 
     def get_files(self):
-        folder_files = []
-        if self.folder_src:
-            for folder in self.folder_src.files:
-                folder_files.append(folder)
-        return folder_files
+        if not self.folder_src:
+            return []
+        return list(self.folder_src.files)


### PR DESCRIPTION
Reduce number of lines and complexity of the method.

There is no need to loop over the `QuerySet` in order to convert it to `list`. Actually I think that there is no need to convert it to `list` at all and just return the `QuerySet`, but if it is the intended behavior of the method then this version should be more readable.